### PR TITLE
feat: improve background styles and clean up globals

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,8 +3,8 @@
 :host,
 :root {
   --animate-bg-init: bg-pan 15s ease infinite, fade-in 500ms ease 1 backwards;
-  --color-primary: 2, 6, 23;
-  --color-secondary: 241, 245, 249;
+  --color-primary: 2 6 23;
+  --color-secondary: 241 245 249;
   --color-tertiary: oklch(37.2% 0.044 257.287deg);
   --container-lg: 32rem;
   --default-transition-duration: 0.15s;
@@ -17,25 +17,20 @@
   --text-3xl: 1.875rem;
   --text-5xl-line-height: 1;
   --text-5xl: 3rem;
-  --text-lg-line-height: calc(1.75 / 1.125);
   --text-lg: 1.125rem;
   --text-sm-line-height: calc(1.25 / 0.875);
   --tracking-tight: -0.025em;
   --tracking-tighter: -0.05em;
 }
 
-html {
-  box-sizing: border-box;
-}
-
 *,
 *::before,
 *::after {
-  box-sizing: inherit;
+  box-sizing: border-box;
 }
 
-body,
-html {
+html,
+body {
   height: 100%;
   margin: 0;
   padding: 0;
@@ -47,7 +42,6 @@ body {
   font-family: var(--font-sans);
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-  line-height: inherit;
 
   @media screen and (prefers-color-scheme: dark) {
     --color-primary: 112 128 144;
@@ -77,25 +71,21 @@ h5 {
     background-position: 0% 50%;
   }
 
-  100% {
-    background-position: 0% 50%;
-  }
-
   50% {
     background-position: 100% 50%;
+  }
+
+  100% {
+    background-position: 0% 50%;
   }
 }
 
 @keyframes fade-in {
-  0% {
-    opacity: 0.01;
-  }
-
-  1% {
+  from {
     opacity: 0;
   }
 
-  100% {
+  to {
     opacity: 1;
   }
 }

--- a/src/components/HomePage/HomePage.module.css
+++ b/src/components/HomePage/HomePage.module.css
@@ -12,8 +12,22 @@
   display: flex;
   min-height: 100%;
   padding: calc(var(--spacing) * 6);
+  position: relative;
   transform: translateZ(0);
   will-change: background-position;
+
+  &::before {
+    animation: bg-pan 25s ease-in-out infinite reverse;
+    background-image:
+      radial-gradient(circle at 20% 80%, var(--color-bg-5) 0%, transparent 50%),
+      radial-gradient(circle at 80% 20%, var(--color-bg-6) 0%, transparent 50%);
+    background-size: 400%;
+    content: '';
+    inset: 0;
+    mix-blend-mode: soft-light;
+    position: absolute;
+    will-change: background-position;
+  }
 
   @media (width >= 48rem) {
     align-items: center;
@@ -24,4 +38,5 @@
 
 .content {
   mix-blend-mode: overlay;
+  position: relative;
 }

--- a/src/components/HomePage/index.tsx
+++ b/src/components/HomePage/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useLayoutEffect, useRef } from 'react'
+import { useCallback } from 'react'
 import { Header } from 'components/Header'
 import { Social } from 'components/Social'
 import { APP_DATA, SOCIAL_DATA } from 'constant'
@@ -9,14 +9,14 @@ import { setBackgroundStyles } from 'utils'
 import styles from './HomePage.module.css'
 
 export const HomePage = () => {
-  const backgroundElemRef = useRef<HTMLElement>(null)
-
-  useLayoutEffect(() => {
-    setBackgroundStyles(backgroundElemRef.current)
+  const backgroundRef = useCallback((element: HTMLElement | null) => {
+    if (element) {
+      setBackgroundStyles(element)
+    }
   }, [])
 
   return (
-    <main className={styles.wrapper} ref={backgroundElemRef}>
+    <main className={styles.wrapper} ref={backgroundRef}>
       <article className={styles.content}>
         <Header {...APP_DATA} />
         <Social data={SOCIAL_DATA} />

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,26 +14,27 @@ const randomMinMax = (min: number, max: number): number => {
   return Math.floor(Math.random() * (max - min) + min)
 }
 
+interface HSLColorOptions {
+  lightness?: { max?: number; min?: number }
+  opacity?: number
+  saturation?: { max?: number; min?: number }
+}
+
 /**
  * Generate a random HSL color string.
  *
- * @param {number} [saturationMin=50] Minimum saturation percentage.
- * @param {number} [saturationMax=100] Maximum saturation percentage.
- * @param {number} [lightnessMin=50] Minimum lightness percentage.
- * @param {number} [lightnessMax=100] Maximum lightness percentage.
- * @param {number} [opacity=25] Opacity as a percentage.
+ * @param {HSLColorOptions} [options] Configuration for saturation,
+ * lightness, and opacity ranges.
  * @returns {string} HSL color string in the format "hsl(h s% l% / a%)".
  */
-export const randomHSLColor = (
-  saturationMin: number = 50,
-  saturationMax: number = 100,
-  lightnessMin: number = 50,
-  lightnessMax: number = 100,
-  opacity: number = 25,
-): string => {
+export const randomHSLColor = ({
+  lightness: { max: lMax = 100, min: lMin = 50 } = {},
+  opacity = 25,
+  saturation: { max: sMax = 100, min: sMin = 50 } = {},
+}: HSLColorOptions = {}): string => {
   const h = randomMinMax(0, 360)
-  const s = randomMinMax(saturationMin, saturationMax)
-  const l = randomMinMax(lightnessMin, lightnessMax)
+  const s = randomMinMax(sMin, sMax)
+  const l = randomMinMax(lMin, lMax)
 
   return `hsl(${h} ${s}% ${l}% / ${opacity}%)`
 }
@@ -41,18 +42,13 @@ export const randomHSLColor = (
 /**
  * Set CSS custom properties with random HSL colors on an element.
  *
- * @param {HTMLElement | null} element The element to apply styles to.
+ * @param {HTMLElement} element The element to apply styles to.
  * @param {number} [colorCount=4] The number of random colors to generate.
- * @throws {Error} If element is null or not a valid HTMLElement.
  */
 export const setBackgroundStyles = (
-  element: HTMLElement | null,
-  colorCount: number = 4,
+  element: HTMLElement,
+  colorCount: number = 6,
 ): void => {
-  if (!element) {
-    throw new Error('A valid HTMLElement must be provided.')
-  }
-
   for (let i = 0; i < colorCount; i++) {
     element.style.setProperty(`--color-bg-${i + 1}`, randomHSLColor())
   }

--- a/src/utils/utils.test.tsx
+++ b/src/utils/utils.test.tsx
@@ -14,17 +14,23 @@ describe('utils', () => {
 
   describe('randomMinMax', () => {
     it('throws when min is greater than max', () => {
-      expect(() => randomHSLColor(100, 50)).toThrow()
+      expect(() =>
+        randomHSLColor({ saturation: { max: 50, min: 100 } }),
+      ).toThrow()
     })
 
     it('throws when min equals max', () => {
-      expect(() => randomHSLColor(50, 50)).toThrow()
+      expect(() =>
+        randomHSLColor({ saturation: { max: 50, min: 50 } }),
+      ).toThrow()
     })
 
     it('returns values within the specified range', () => {
       vi.restoreAllMocks()
 
-      const results = Array.from({ length: 100 }, () => randomHSLColor(30, 60))
+      const results = Array.from({ length: 100 }, () =>
+        randomHSLColor({ saturation: { max: 60, min: 30 } }),
+      )
 
       results.forEach((color) => {
         const match = color.match(/hsl\((\d+)\s+(\d+)%\s+(\d+)%/)
@@ -53,19 +59,19 @@ describe('utils', () => {
     })
 
     it('respects custom saturation range', () => {
-      const hsl = randomHSLColor(30, 60)
+      const hsl = randomHSLColor({ saturation: { max: 60, min: 30 } })
 
       expect(hsl).toBe('hsl(360 60% 100% / 25%)')
     })
 
     it('respects custom lightness range', () => {
-      const hsl = randomHSLColor(50, 100, 20, 80)
+      const hsl = randomHSLColor({ lightness: { max: 80, min: 20 } })
 
       expect(hsl).toBe('hsl(360 100% 80% / 25%)')
     })
 
     it('respects custom opacity', () => {
-      const hsl = randomHSLColor(50, 100, 50, 100, 50)
+      const hsl = randomHSLColor({ opacity: 50 })
 
       expect(hsl).toBe('hsl(360 100% 100% / 50%)')
     })
@@ -81,15 +87,6 @@ describe('utils', () => {
   })
 
   describe('setBackgroundStyles', () => {
-    it('throws when no element is provided', () => {
-      expect(() => setBackgroundStyles(null as any)).toThrow(
-        'A valid HTMLElement must be provided.',
-      )
-      expect(() => setBackgroundStyles(undefined as any)).toThrow(
-        'A valid HTMLElement must be provided.',
-      )
-    })
-
     it('sets the expected CSS custom properties on the provided element with default color count', () => {
       const mainEl = document.createElement('main')
 
@@ -102,7 +99,9 @@ describe('utils', () => {
       expect(mainEl.style.getPropertyValue('--color-bg-2')).toBe(defaultHslStr)
       expect(mainEl.style.getPropertyValue('--color-bg-3')).toBe(defaultHslStr)
       expect(mainEl.style.getPropertyValue('--color-bg-4')).toBe(defaultHslStr)
-      expect(mainEl.style.getPropertyValue('--color-bg-5')).toBe('')
+      expect(mainEl.style.getPropertyValue('--color-bg-5')).toBe(defaultHslStr)
+      expect(mainEl.style.getPropertyValue('--color-bg-6')).toBe(defaultHslStr)
+      expect(mainEl.style.getPropertyValue('--color-bg-7')).toBe('')
     })
 
     it('sets custom number of CSS custom properties', () => {


### PR DESCRIPTION
- Replace useRef + useLayoutEffect with a callback ref in HomePage
- Refactor randomHSLColor to accept an options object instead of positional params
- Tighten setBackgroundStyles to accept non-null HTMLElement
- Add layered radial gradient blobs with counter-animation for depth
- Standardize CSS color variables to space-separated format
- Fix keyframe ordering and simplify fade-in animation
- Modernize box-sizing reset and remove unused --text-lg-line-height
- Update tests to match new API and default color count