### PR TITLE
Header top-left alignment + lint-staged pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn lint-staged && yarn lint && yarn test:coverage
+yarn lint-staged

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,0 @@
-{
-  "*.{css,html,js,md,mjs,ts,tsx}": "prettier --write"
-}

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,0 +1,9 @@
+export default {
+  // ponytail: prettier gets the staged files; lint + tests ignore them and
+  // run project-wide (tsc needs the whole project; coverage needs the full suite).
+  '*.{css,html,js,md,mjs,ts,tsx}': [
+    'prettier --write',
+    () => 'yarn lint',
+    () => 'yarn test:coverage',
+  ],
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,10 @@ Package manager is **Yarn 4** (see `packageManager` in `package.json`). Node 24
 - Run a single test file: `yarn test src/utils/__tests__/utils.test.tsx`
 - Run by test name: `yarn test -t 'partial name'`
 
-The Husky pre-commit hook runs `yarn format && yarn lint && yarn test:coverage`.
-If a hook fails, fix the underlying issue rather than bypassing it — never use
-`--no-verify`.
+The Husky pre-commit hook runs `yarn lint-staged`, whose config
+(`.lintstagedrc.mjs`) runs `prettier --write` on staged files and then full
+`yarn lint` and `yarn test:coverage`. If a hook fails, fix the underlying issue
+rather than bypassing it — never use `--no-verify`.
 
 ## Architecture
 

--- a/src/components/HomePage/HomePage.module.css
+++ b/src/components/HomePage/HomePage.module.css
@@ -30,8 +30,6 @@
   }
 
   @media (width >= 48rem) {
-    align-items: center;
-    justify-content: center;
     padding-inline: calc(var(--spacing) * 8);
   }
 }


### PR DESCRIPTION
## Summary
- Align home header content top-left on desktop (drop `justify-content`/`align-items: center` on the wrapper at ≥48rem)
- Run the full `yarn lint` + `yarn test:coverage` through `lint-staged` so the pre-commit hook is just `yarn lint-staged`; replace `.lintstagedrc.json` with `.lintstagedrc.mjs` (function form needed for project-wide commands)
- Update CLAUDE.md to document the new hook

## Test plan
- `yarn lint-staged` runs prettier on staged files, then full lint + coverage — verified green locally